### PR TITLE
fix: install script を指定していない場合はタグそのものを削除する必要があったので対応

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12076,6 +12076,10 @@ class MacOSHelper {
      * @returns
      */
     static Generate(rootRelativeBundlePath, bundleHasStrictIdentifier = true, bundleIsRelocatable = false, bundleIsVersionChecked = true, bundleOverwriteAction = true, bundlePostInstallScriptPath = '', bundlePreInstallScriptPath = '') {
+        const bundlePostInstallScriptPathNode = `<key>BundlePostInstallScriptPath</key>
+<string>${bundlePostInstallScriptPath}</string>`;
+        const bundlePreInstallScriptPathNode = `<key>BundlePreInstallScriptPath</key>
+<string>${bundlePreInstallScriptPath}</string>`;
         return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -12091,10 +12095,8 @@ class MacOSHelper {
     <string>${bundleOverwriteAction ? 'upgrade' : 'update'}</string>
     <key>RootRelativeBundlePath</key>
     <string>${rootRelativeBundlePath}</string>
-    <key>BundlePostInstallScriptPath</key>
-    <string>${bundlePostInstallScriptPath}</string>
-    <key>BundlePreInstallScriptPath</key>
-    <string>${bundlePreInstallScriptPath}</string>
+    ${bundlePostInstallScriptPath ? bundlePostInstallScriptPathNode : ''}
+    ${bundlePreInstallScriptPath ? bundlePreInstallScriptPathNode : ''}
   </dict>
 </array>
 </plist>`;

--- a/src/MacOSHelper.ts
+++ b/src/MacOSHelper.ts
@@ -70,6 +70,10 @@ export default class MacOSHelper
         bundlePostInstallScriptPath: string = '',
         bundlePreInstallScriptPath: string = ''): string
     {
+        const bundlePostInstallScriptPathNode = `<key>BundlePostInstallScriptPath</key>
+<string>${bundlePostInstallScriptPath}</string>`
+        const bundlePreInstallScriptPathNode = `<key>BundlePreInstallScriptPath</key>
+<string>${bundlePreInstallScriptPath}</string>`
         return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -85,10 +89,8 @@ export default class MacOSHelper
     <string>${bundleOverwriteAction ? 'upgrade' : 'update'}</string>
     <key>RootRelativeBundlePath</key>
     <string>${rootRelativeBundlePath}</string>
-    <key>BundlePostInstallScriptPath</key>
-    <string>${bundlePostInstallScriptPath}</string>
-    <key>BundlePreInstallScriptPath</key>
-    <string>${bundlePreInstallScriptPath}</string>
+    ${bundlePostInstallScriptPath ? bundlePostInstallScriptPathNode : ''}
+    ${bundlePreInstallScriptPath ? bundlePreInstallScriptPathNode : ''}
   </dict>
 </array>
 </plist>`;


### PR DESCRIPTION
bundlePostInstallScriptPath や bundlePreInstallScriptPath を指定しない場合、 pkgbuild に指定する plist に install script の要素を含めないように修正いたしました。(これがインストール時のエラーの要因になっていました)